### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LUCI_DESCRIPTION:=provides Web UI to shut down (power off) your device.
 
 LUCI_PKGARCH:=all
 PKG_VERSION:=1
-PKG_RELEASE:=3 
+PKG_RELEASE:=3
 
 include $(TOPDIR)/feeds/luci/luci.mk
 


### PR DESCRIPTION
Packaged contents of /workdir/openwrt/build_dir/target-aarch64_generic_musl/luci-app-poweroffdevice/ipkg-all/luci-app-poweroffdevice into /workdir/openwrt/bin/packages/aarch64_generic/small8/luci-app-poweroffdevice_1-3 _all.ipk
1.根据上方提示：luci-app-poweroffdevice_1-3 _all.ipk 此处多了空格
2.编辑/home/home/lede/feeds/full/luci-app-poweroffdevice/Makefile
include $(TOPDIR)/rules.mk

PKG_NAME:=luci-app-poweroffdevice
LUCI_TITLE:=LuCI support for poweroffdevice Router
LUCI_DESCRIPTION:=provides Web UI to shut down (power off) your device. 

LUCI_PKGARCH:=all
PKG_VERSION:=1
PKG_RELEASE:=3 

include $(TOPDIR)/feeds/luci/luci.mk
发现ipk文件名是由'PKG_NAME_PKG_VERSION_PKG_RELEASE_LUCI_PKGARCH.ipk'组成，其中PKG_RELEASE:=3 多了一个空格，造成问题，删掉即可